### PR TITLE
Fix ESM strict mode error

### DIFF
--- a/src/cp/files/script.js
+++ b/src/cp/files/script.js
@@ -1,7 +1,7 @@
-const arguments = process.argv.slice(2);
+const args = process.argv.slice(2);
 
-console.log(`Total number of arguments is ${arguments.length}`);
-console.log(`Arguments: ${JSON.stringify(arguments)}`);
+console.log(`Total number of arguments is ${args.length}`);
+console.log(`Arguments: ${JSON.stringify(args)}`);
 
 const echoInput = (chunk) => {
     const chunkStringified = chunk.toString();


### PR DESCRIPTION
Commit 145bcef9c9d9059107f9973de71f1fc885cf3a18 changes default modules format from commonjs to esm which forces all modules to be evaluated in strict mode. It breaks `arguments` variable usage in src/cp/files/script.js module:

```
$ node src/cp/files/script.js
file:///home/eugene/workspace/rss/node-nodejs-basics/src/cp/files/script.js:1
const arguments = process.argv.slice(2);
      ^^^^^^^^^

SyntaxError: Unexpected eval or arguments in strict mode
    at ESMLoader.moduleStrategy (node:internal/modules/esm/translators:117:18)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:337:14)
    at async link (node:internal/modules/esm/module_job:70:21)
```

Renaming `arguments` to `args` fixes this issue.