### PR TITLE
Small fixes `cjsToEsm` after extension rename to `.cjs`

### DIFF
--- a/src/modules/cjsToEsm.cjs
+++ b/src/modules/cjsToEsm.cjs
@@ -1,7 +1,7 @@
 const path = require('path');
 const { release, version } = require('os');
 const { createServer: createServerHttp } = require('http');
-require('./files/c');
+require('./files/c.cjs');
 
 const random = Math.random();
 

--- a/src/modules/files/c.cjs
+++ b/src/modules/files/c.cjs
@@ -1,1 +1,1 @@
-console.log('Hello from c.js!');
+console.log('Hello from c.cjs!');


### PR DESCRIPTION
### Fixes

#### `cjsToEsm.cjs`
* missing extension in `require('./files/c')`
* log message typo in `c.cjs`